### PR TITLE
Support to Dialogue Panel Rework mod. 

### DIFF
--- a/NoFishingQuestsUI.cs
+++ b/NoFishingQuestsUI.cs
@@ -95,7 +95,7 @@ internal class NoFishingQuestsUI : UIState
 	}
 
 	// copied from Main.OpenShop (except the line with the comment)
-	private static void OpenShop(int shopIndex)
+	internal static void OpenShop(int shopIndex)
 	{
 		Main.playerInventory = true;
 		Main.stackSplit = 9999;

--- a/UISystem.cs
+++ b/UISystem.cs
@@ -1,7 +1,9 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
+using System;
 using System.Collections.Generic;
 using Terraria;
 using Terraria.ID;
+using Terraria.Localization;
 using Terraria.ModLoader;
 using Terraria.UI;
 
@@ -11,6 +13,7 @@ internal class UISystem : ModSystem
 {
 	internal UserInterface UserInterface;
 	private UIState UI;
+	private static bool dialogueTweakLoaded = false;
 
 	public override void Load()
 	{
@@ -27,6 +30,21 @@ internal class UISystem : ModSystem
 	{
 		UI = null;
 		UserInterface = null;
+	}
+
+	public override void PostSetupContent() {
+		if (ModLoader.TryGetMod("DialogueTweak", out Mod dialogueTweak)) {
+			dialogueTweakLoaded = true;
+			dialogueTweak.Call(
+				"AddButton",
+				NPCID.Angler, // NPC ID
+				(Func<string>)(() => Language.GetTextValue("LegacyInterface.28")),
+				"DialogueTweak/Interfaces/Assets/Icon_Default", // The texture's path
+				(Action)(() => {
+					if (Main.mouseLeft)
+						NoFishingQuestsUI.OpenShop(99);
+				}));
+		}
 	}
 
 	private GameTime _lastUpdateUiGameTime;
@@ -50,8 +68,8 @@ internal class UISystem : ModSystem
 				"NoFishingQuests: UI",
 				delegate
 				{
-						// if the player is talking to the Angler and the new shop isn't opened
-						if (Main.LocalPlayer.talkNPC != -1 && Main.npc[Main.LocalPlayer.talkNPC].type == NPCID.Angler && Main.npcShop != 99)
+						// if the player is talking to the Angler, the new shop isn't opened and dialogue tweak mod isn't active.
+						if (Main.LocalPlayer.talkNPC != -1 && Main.npc[Main.LocalPlayer.talkNPC].type == NPCID.Angler && Main.npcShop != 99 && !dialogueTweakLoaded)
 					{
 						UserInterface.Draw(Main.spriteBatch, _lastUpdateUiGameTime);
 					}


### PR DESCRIPTION
Add support to the newest version of Dialogue Panel Rework mod.
I am the author of Dialogue Panel Rework mod. In the newest version of the mod, I added a Mod.Call "AddButton" so that modders can add their own buttons to NPCs.
Someone just told me in the steam workshop page that Dialogue Panel Rework mod doesn't work perfectly with No Fishing Quest mod. So I made this simple pr which adds a Mod.Call to support the panel rework mod.